### PR TITLE
check for clock_getcpuclockid via discover

### DIFF
--- a/discover/discover.ml
+++ b/discover/discover.ml
@@ -20,6 +20,7 @@ int main()
   clock_gettime(CLOCK_REALTIME, &ts);
   clock_settime(CLOCK_REALTIME, &ts);
   clock_getres(CLOCK_REALTIME, &ts);
+  clock_getcpuclockid(0, CLOCK_REALTIME);
   return 0;
 }
 |}


### PR DESCRIPTION
enabling JSC_POSIX_TIMERS attempts to use clock_getcpuclockid in
core_unix, which leads to compilation errors in macOS where this call is
missing.

Signed-off-by: Anurag Soni <anurag@sonianurag.com>