### PR TITLE
fix wrong thread_id detection due to implicit-function-declaration error

### DIFF
--- a/src/thread_id.h
+++ b/src/thread_id.h
@@ -7,6 +7,7 @@
 #if JSC_THREAD_ID_METHOD == 1
 
 #include <sys/syscall.h>
+#include <unistd.h>
 
 #define GET_THREAD_ID syscall(SYS_gettid)
 


### PR DESCRIPTION
Hi there,

syscall() is actually not properly included currently, but because of c89's legacy, compiler used to fill in an implicit declaration like
`extern int syscall()`, which accepts any number of argument with same function name, and issued an implicit declaration warning. This issue went unnoticed till today.
clang-16 and future version of gcc now makes this warning into an error to finally get rid of this bad legacy.

It causes mysterious bug like https://bugs.gentoo.org/878623, with compilation failure,
```
/usr/bin/x86_64-pc-linux-gnu-ld.bfd: /usr/lib64/ocaml/core/linux_ext/linux_ext.a(
linux_ext.o): in function `camlLinux_ext__sched_setaffinity_this_thread_34519':  
(.text+0x4600): undefined reference to `core_unix_gettid'
/usr/bin/x86_64-pc-linux-gnu-ld.bfd: /usr/lib64/ocaml/core/linux_ext/linux_ext.a(
linux_ext.o): in function `camlLinux_ext__1':
(.data+0x3b58): undefined reference to `core_unix_gettid'
```

This pr includes the header `unistd.h` that declares syscall