### PR TITLE
Fix mkostemp discovery for C99 compatibility

### DIFF
--- a/discover/discover.ml
+++ b/discover/discover.ml
@@ -136,6 +136,7 @@ int main () {
 |}
 
 let mkostemp_code = {|
+#define _GNU_SOURCE
 #include <stdlib.h>
 
 int main () {


### PR DESCRIPTION
Define _GNU_SOURCE so that <stdlib.h> declares mkostemp.

This avoids implicit function declarations and build failures with future compilers.

Related to:

* https://fedoraproject.org/wiki/Changes/PortingToModernC
* https://fedoraproject.org/wiki/Toolchain/PortingToModernC
